### PR TITLE
Replaced zipOutputStream.flush() introduced in version 1.2.3 with BufferedOutputStream

### DIFF
--- a/src/main/java/no/ks/fiks/io/asice/read/EncryptedAsicReaderImpl.java
+++ b/src/main/java/no/ks/fiks/io/asice/read/EncryptedAsicReaderImpl.java
@@ -48,7 +48,7 @@ public class EncryptedAsicReaderImpl implements EncryptedAsicReader {
             final Map<String, String> mdc = MDC.getCopyOfContextMap();
             executorService.execute(() -> {
                 Optional.ofNullable(mdc).ifPresent(MDC::setContextMap);
-                try (ZipOutputStream zipOutputStream = new ZipOutputStream(out)) {
+                try (ZipOutputStream zipOutputStream = new ZipOutputStream(new BufferedOutputStream(out))) {
                     decrypt(encryptedAsicData, zipOutputStream, privateKey);
                 } catch (IOException e) {
                     log.error("Failed to decrypt stream", e);

--- a/src/main/java/no/ks/fiks/io/asice/read/EncryptedAsicReaderImpl.java
+++ b/src/main/java/no/ks/fiks/io/asice/read/EncryptedAsicReaderImpl.java
@@ -97,7 +97,6 @@ public class EncryptedAsicReaderImpl implements EncryptedAsicReader {
                 zipOutputStream.putNextEntry(new ZipEntry(filnavn));
                 reader.writeFile(zipOutputStream);
                 zipOutputStream.closeEntry();
-                zipOutputStream.flush();
             }
 
             if (!entryAdded)
@@ -119,5 +118,4 @@ public class EncryptedAsicReaderImpl implements EncryptedAsicReader {
         InputStream inputStream = decryptionStreamService.decrypterStream(encryptedAsic, privatNokkel);
         decryptElementer(encryptedAsic, zipOutputStream, inputStream);
     }
-
 }


### PR DESCRIPTION
Vi har nå testet fiks-io-klient-java 2.0.11 i flere miljøer for å verifisere endringene som er utført. Testene har avdekket at `zipOutputStream.flush()` gir problemer i enkelte sammenhenger, og er derfor fjernet i denne PRen.

Ved å pakke inn `PipedOutputStream` slik
`try (ZipOutputStream zipOutputStream = new ZipOutputStream(new BufferedOutputStream(out)))`
fikk vi fjernet feilmeldingene `Pipe Closed`.

Endringen er testet i alle miljøer vi benytter over 16 timer med sending/mottak av mer enn 100 000 meldinger.

Gjennomføring av testen:
- Applikasjonene ble bygget med en lokal versjon av fiks-io-asice-handler med endringene i denne PRen
- Java klientapplikasjon, som benytter fiks-io-klient-java, sendte meldinger med generert innhold (barnevern) til barnevernsregisterarkitekturen med 300ms pause mellom hver melding. 
- Applikasjon i GKE som også benytter fiks-io-klient-java, prosesserte meldingene og sendte svar til klientapplikasjon. Klientapplikasjon inneholdt tellere for antall sendte og mottatte meldinger, samt antall feil ved sending/mottak av meldinger.

Logger Google Cloud ble regelmessig undersøkt.

Resultat av testen:
Number of messages sent: 114491
Number of messages received: 114491
Number of send errors: 73
Number of receive errors: 0

Ikke relatert til endringene i denne PRen: Vi registrerte en del feil i loggene under testen i forbindelse med utsendelse, men dette klarer vi å håndtere. I snitt 8 slike unntak per time.

```
Caused by: java.util.concurrent.ExecutionException: java.io.EOFException: HttpConnectionOverHTTP@39246dc4::DecryptedEndPoint@3b48141b{l=/10.17.7.62:46534,r=api.fiks.test.ks.no/137.221.28.81:443,OPEN,fill=-,flush=-,to=403/0}
	at org.eclipse.jetty.client.util.InputStreamResponseListener.get(InputStreamResponseListener.java:221)
	at no.ks.fiks.io.klient.FiksIOUtsendingKlient.send(FiksIOUtsendingKlient.java:66)
	... 21 common frames omitted
Caused by: java.io.EOFException: HttpConnectionOverHTTP@39246dc4::DecryptedEndPoint@3b48141b{l=/10.17.7.62:46534,r=api.fiks.test.ks.no/137.221.28.81:443,OPEN,fill=-,flush=-,to=403/0}
	at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.earlyEOF(HttpReceiverOverHTTP.java:385)
	at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:1620)
	at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.shutdown(HttpReceiverOverHTTP.java:269)
	at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.process(HttpReceiverOverHTTP.java:185)
	at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.receive(HttpReceiverOverHTTP.java:80)
	at org.eclipse.jetty.client.http.HttpChannelOverHTTP.receive(HttpChannelOverHTTP.java:131)
	at org.eclipse.jetty.client.http.HttpConnectionOverHTTP.onFillable(HttpConnectionOverHTTP.java:172)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:555)
	at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:410)
	at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:164)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
	... 1 common frames omitted
```