### PR TITLE
Oppdaterer avhengigheter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <slf4j.version>2.0.7</slf4j.version>
         <guava.version>32.1.1-jre</guava.version>
 
-        <junit.version>5.9.3</junit.version>
+        <junit.version>5.10.0</junit.version>
         <assertj.version>3.24.2</assertj.version>
         <mockito.version>5.4.0</mockito.version>
     </properties>

--- a/src/main/java/no/ks/fiks/io/asice/AsicHandler.java
+++ b/src/main/java/no/ks/fiks/io/asice/AsicHandler.java
@@ -12,13 +12,33 @@ import java.util.zip.ZipInputStream;
  * Handles creation, validation, encryption and decryption of AsicE packages
  */
 public interface AsicHandler extends AutoCloseable {
+    /**
+     * Creates a new AsicHandlerBuilder
+     * @return a new AsicHandlerBuilder
+     */
     static AsicHandlerBuilder builder() {
         return AsicHandlerBuilder.create();
     }
 
+    /**
+     * Encrypts the payload using the given certificate
+     * @param mottakerCert the certificate to encrypt with
+     * @param payload the payload to encrypt
+     * @return an inputstream containing the encrypted payload
+     */
     InputStream encrypt(X509Certificate mottakerCert, List<Content> payload);
 
+    /**
+     * Decryptes the given asic-e package
+     * @param encryptedAsicData the asic-e package to decrypt
+     * @return an inputstream containing the decrypted payload
+     */
     ZipInputStream decrypt(InputStream encryptedAsicData);
 
+    /**
+     * Decryptes the given asic-e package and writes the decrypted payload to the given path
+     * @param encryptedAsicData the asic-e package to decrypt
+     * @param targetPath the path to write the decrypted payload to
+     */
     void writeDecrypted(InputStream encryptedAsicData, Path targetPath);
 }

--- a/src/main/java/no/ks/fiks/io/asice/model/Content.java
+++ b/src/main/java/no/ks/fiks/io/asice/model/Content.java
@@ -2,7 +2,17 @@ package no.ks.fiks.io.asice.model;
 
 import java.io.InputStream;
 
+/**
+ * Represents a file in an asic-e package
+ */
 public interface Content {
+    /**
+     * @return the filename of the file
+     */
     String getFilnavn();
+
+    /**
+     * @return the contents an inputstream
+     */
     InputStream getPayload();
 }


### PR DESCRIPTION
- Bump org.junit:junit-bom from 5.9.3 to 5.10.0
- Bump org.bouncycastle:bcpkix-jdk18on from 1.75 to 1.76
- Bump com.google.guava:guava from 32.1.1-jre to 32.1.2-jre
- Bump ch.qos.logback:logback-classic from 1.4.8 to 1.4.11
- Bump no.ks.fiks:kryptering from 2.0.1 to 2.0.2
