### PR TITLE
Oppdatert dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>no.ks.fiks.pom</groupId>
         <artifactId>fiks-ekstern-super-pom</artifactId>
-        <version>1.2.4</version>
+        <version>1.4.0</version>
     </parent>
     <groupId>no.ks.fiks</groupId>
     <artifactId>fiks-io-asice-handler</artifactId>
@@ -28,17 +28,17 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <difi-commons-asic.version>1.0.2</difi-commons-asic.version>
-        <bouncycastle.version>1.78.1</bouncycastle.version>
+        <bouncycastle.version>1.79</bouncycastle.version>
         <lombok.version>1.18.34</lombok.version>
         <jaxb-runtime.version>4.0.5</jaxb-runtime.version>
-        <kryptering.version>2.0.5</kryptering.version>
-        <logback.version>1.5.6</logback.version>
+        <kryptering.version>2.0.8</kryptering.version>
+        <logback.version>1.5.18</logback.version>
         <slf4j.version>2.0.16</slf4j.version>
-        <guava.version>33.2.1-jre</guava.version>
+        <guava.version>33.4.8-jre</guava.version>
 
-        <junit.version>5.10.3</junit.version>
+        <junit.version>5.13.4</junit.version>
         <assertj.version>3.26.3</assertj.version>
-        <mockito.version>5.12.0</mockito.version>
+        <mockito.version>5.14.2</mockito.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This pull request updates several dependencies and the parent POM version in the `pom.xml` file to keep the project up to date with the latest releases and security patches. The changes focus on upgrading core libraries, testing frameworks, and the parent POM.

Dependency and version upgrades:

* Upgraded parent POM to `fiks-ekstern-super-pom` version `1.4.0` for improved build and dependency management.
* Updated core library versions: `bouncycastle` to `1.79`, `kryptering` to `2.0.8`, `logback` to `1.5.18`, and `guava` to `33.4.8-jre` for enhanced security and features.
* Upgraded testing dependencies: `junit` to `5.13.4` and `mockito` to `5.14.2` for better testing support and bug fixes.